### PR TITLE
fix: add validation and send a bad request response when trying to create another profile

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -55,13 +55,11 @@ class ProfileSerializer(serializers.ModelSerializer):
         runner_tag = validated_data.pop('runner_tag', [])
         profile = Profile(**validated_data)
 
-            # def validate(self, attrs):
-            #     profile_exists = Profile.objects.filter(runner_tag = attrs['runner_tag']).exists()
+        user_id = self.context['request'].user.id
 
-            #     if profile_exists:
-            #         raise serializers.ValidationError(detail="Username already exists")
-
-            #     return super().validate(attrs)
+        # Validation: Send Error message when profile is exist
+        if Profile.objects.filter(user_id=user_id).exists():
+            raise serializers.ValidationError({"message": "Profile is already exist"})
 
         profile.save()
         self._get_or_create_runner_level(runner_level, profile)


### PR DESCRIPTION
As 1 user may only allow to have 1 profile, and prevent directing the endpoint to Django error's page.